### PR TITLE
docs(main): add module header to clarify env usage & set default scrape interval to 15s for Prometheus compatibility

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ import (
 
  Required ENV variables:
  - ADGUARD_HOST        : AdGuard Home base URL (e.g. http://192.168.1.1:3000)
- - ADGUARD_USER        : API username
- - ADGUARD_PASS        : API password
+ - ADGUARD_USER        : API username (your adguard user)
+ - ADGUARD_PASS        : API password (your adguard pass)
  - EXPORTER_PORT       : Port to expose metrics (default: 9617)
  - SCRAPE_INTERVAL     : Interval (in seconds) to fetch new stats (default: 15)
 */

--- a/main.go
+++ b/main.go
@@ -15,6 +15,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+/*
+ 📦 AdGuard Exporter for Prometheus
+ ----------------------------------
+ Author   : @znand-dev
+ License  : MIT
+ Repo     : https://github.com/znand-dev/adguardexporter
+
+ This Go application fetches stats from AdGuard Home via API endpoints
+ and exposes them as Prometheus metrics at `/metrics`.
+
+ Required ENV variables:
+ - ADGUARD_HOST        : AdGuard Home base URL (e.g. http://192.168.1.1:3000)
+ - ADGUARD_USER        : API username
+ - ADGUARD_PASS        : API password
+ - EXPORTER_PORT       : Port to expose metrics (default: 9617)
+ - SCRAPE_INTERVAL     : Interval (in seconds) to fetch new stats (default: 15)
+*/
+
 type AdGuardStats struct {
 	NumDNSQueries       float64              `json:"num_dns_queries"`
 	NumBlockedFiltering float64              `json:"num_blocked_filtering"`
@@ -301,7 +319,7 @@ func main() {
 	}
 	interval, err := strconv.Atoi(scrapeIntervalStr)
 	if err != nil || interval < 1 {
-		interval = 30
+		interval = 15
 	}
 
 	go func() {


### PR DESCRIPTION
### Summary

This PR improves documentation and config behavior by:

- Adding a structured header block at the top of `main.go`
- Clarifying environment variable usage
- Setting default `SCRAPE_INTERVAL` to **15s**, which aligns better with Prometheus scraping standards

No other logic was changed. Metrics and exporter behavior remain consistent.

---

### ✅ Environment Variables:

| Variable         | Default | Description                             |
|------------------|---------|-----------------------------------------|
| `ADGUARD_HOST`   | –       | URL to your AdGuard Home instance       |
| `ADGUARD_USER`   | –       | Basic auth username                     |
| `ADGUARD_PASS`   | –       | Basic auth password                     |
| `EXPORTER_PORT`  | 9617    | Port to expose Prometheus metrics       |
| `SCRAPE_INTERVAL`| 15      | Fetch interval in seconds (min: 1 sec)  |

---

Helps improve onboarding and makes exporter more Prometheus-compliant