### PR TITLE
fix: handle error from resp.Body.Close() to satisfy golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-adguard-exporter
+adguardexporter
 dist/
 # Env file
 .env

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yourusername/adguard-exporter
+module github.com/znand-dev/adguardexporter
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -194,7 +194,12 @@ func fetchStats() (*AdGuardStats, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+            if err := resp.Body.Close(); err != nil {
+                log.Printf("failed to close response body: %v", err)
+            }
+        }()
+
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -224,7 +229,11 @@ func fetchStatus() (*AdGuardStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+            if err := resp.Body.Close(); err != nil {
+                log.Printf("failed to close response body: %v", err)
+            }
+        }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -254,7 +263,11 @@ func fetchQueryLog() (*AdGuardQueryLog, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+            if err := resp.Body.Close(); err != nil {
+                log.Printf("failed to close response body: %v", err)
+            }
+        }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
This PR fixes unhandled `resp.Body.Close()` calls in `main.go`, which were causing `golangci-lint` to fail due to `errcheck` linter.